### PR TITLE
Support for keys that don't expire

### DIFF
--- a/redis_cache/cache.py
+++ b/redis_cache/cache.py
@@ -197,9 +197,13 @@ class CacheClass(BaseCache):
         try:
             value = int(value)
         except (ValueError, TypeError):
-            result = client.setex(key, pickle.dumps(value), int(timeout))
-        else:
+            value = pickle.dumps(value)
+
+        if timeout <> -1:
             result = client.setex(key, value, int(timeout))
+        else:
+            result = client.set(key, value)
+
         # result is a boolean
         return result
 


### PR DESCRIPTION
Passing a value of -1 for timeout when setting a key will cause it to persist indefinitely. Useful for computationally expensive tasks.

cache.set('key','value',-1)
