### PR TITLE
Add support for persistant keys

### DIFF
--- a/redis_cache/cache.py
+++ b/redis_cache/cache.py
@@ -192,17 +192,18 @@ class CacheClass(BaseCache):
         if not client:
             client = self._client
         key = self.make_key(key, version=version)
-        if not timeout:
-            timeout = self.default_timeout
         try:
             value = int(value)
         except (ValueError, TypeError):
             value = pickle.dumps(value)
 
-        if timeout <> -1:
-            result = client.setex(key, value, int(timeout))
-        else:
-            result = client.set(key, value)
+        if timeout is None:
+            timeout = self.default_timeout
+
+        result = client.set(key, value)
+
+        if timeout <> 0:
+            client.expire(key, timeout)
 
         # result is a boolean
         return result


### PR DESCRIPTION
When setting a key, passing a timeout value of None=use default timeout; 0=persist indefinitely; <=-1=expire instantly. This follows memcache behavior.
