### PR TITLE
Add a way to choose the protocol for pickle.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,8 @@ On Django >= 1.3::
             'OPTIONS': {
                 'DB': 1,
                 'PASSWORD': 'yadayada',
-                'PARSER_CLASS': 'redis.connection.HiredisParser'
+                'PARSER_CLASS': 'redis.connection.HiredisParser',
+                'PICKLE_VERSION': 2 # optional, default to 0
             },
         },
     }
@@ -66,7 +67,8 @@ On Django >= 1.3::
             'OPTIONS': {
                 'DB': 1,
                 'PASSWORD': 'yadayada',
-                'PARSER_CLASS': 'redis.connection.HiredisParser'
+                'PARSER_CLASS': 'redis.connection.HiredisParser',
+                'PICKLE_VERSION': 2 # optional, default to 0
             },
         },
     }

--- a/redis_cache/cache.py
+++ b/redis_cache/cache.py
@@ -76,6 +76,7 @@ class CacheClass(BaseCache):
         super(CacheClass, self).__init__(params)
         self._server = server
         self._params = params
+        self._pickle_version = None
 
         unix_socket_path = None
         if ':' in self.server:
@@ -142,6 +143,20 @@ class CacheClass(BaseCache):
             raise ImproperlyConfigured("Could not find parser class '%s'" % parser_class)
         return parser_class
 
+    @property
+    def pickle_version(self):
+        """
+        Get the pickle version from the settings and save it for future use
+        """
+        if self._pickle_version is None:
+            _pickle_version = self.options.get('PICKLE_VERSION', 0)
+            try:
+                _pickle_version = int(_pickle_version)
+            except (ValueError, TypeError):
+                raise ImproperlyConfigured("pickle version value must be an integer")
+            self._pickle_version = _pickle_version
+        return self._pickle_version
+
     def __getstate__(self):
         return {'params': self._params, 'server': self._server}
 
@@ -207,7 +222,7 @@ class CacheClass(BaseCache):
             if int(value) != value:
                 raise TypeError
         except (ValueError, TypeError):
-            result = self._set(key, pickle.dumps(value), int(timeout), client)
+            result = self._set(key, self.pickle(value), int(timeout), client)
         else:
             result = self._set(key, int(value), int(timeout), client)
         # result is a boolean
@@ -240,6 +255,12 @@ class CacheClass(BaseCache):
         """
         value = smart_str(value)
         return pickle.loads(value)
+
+    def pickle(self, value):
+        """
+        Pickle the given value.
+        """
+        return pickle.dumps(value, self.pickle_version)
 
     def get_many(self, keys, version=None):
         """


### PR DESCRIPTION
Hi

To have a more efficient storage i needed to use another protocol for pickle, so i added a way to change the default one.

Default is 0, and change it by passing another protocol (1 or 2) in the
OPTIONS dict of your cache declaration

This work is based on
https://github.com/arshaver/django-redis/commit/204216808e31338023878dd8055689f0b9674e96

Twidi

PS : sorry for the noise in the list of commits, i don't now how to avoid this, but the diff is correct
