### PR TITLE
Broken boolean values

### DIFF
--- a/redis_cache/cache.py
+++ b/redis_cache/cache.py
@@ -211,7 +211,7 @@ class CacheClass(BaseCache):
             timeout = self.default_timeout
 
         # If ``value`` is not an int, then pickle it
-        if not isinstance(value, int):
+        if not isinstance(value, int) or isinstance(value, bool):
             result = self._set(key, pickle.dumps(value), int(timeout), client, _add_only)
         else:
             result = self._set(key, value, int(timeout), client, _add_only)

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -360,6 +360,12 @@ class RedisCacheTests(TestCase):
         self.assertTrue(self.cache.set("foo", "1"))
         self.assertEqual(self.cache.get("foo"), "1")
 
+    def test_setting_bool_retrieves_bool(self):
+        self.assertTrue(self.cache.set("bool_t", True))
+        self.assertEqual(self.cache.get("bool_t"), True)
+        self.assertTrue(self.cache.set("bool_f", False))
+        self.assertEqual(self.cache.get("bool_f"), False)
+
 
 
 


### PR DESCRIPTION
Boolean values were saved as stringified versions of the boolean value. Therefore boolean values could not be loaded from the cache  as they introduced pickling errors.
