### PR TITLE
CacheKey should derive from str

### DIFF
--- a/redis_cache/cache.py
+++ b/redis_cache/cache.py
@@ -18,25 +18,8 @@ from redis.connection import UnixDomainSocketConnection, Connection
 from redis.connection import DefaultParser
 
 
-class CacheKey(object):
-    """
-    A stub string class that we can use to check if a key was created already.
-    """
-    def __init__(self, key):
-        self._key = key
-
-    def __eq__(self, other):
-        return self._key == other
-
-    def __str__(self):
-        return self.__unicode__()
-
-    def __repr__(self):
-        return self.__unicode__()
-
-    def __unicode__(self):
-        return smart_str(self._key)
-
+class CacheKey(str):
+    pass
 
 class CacheConnectionPool(object):
 

--- a/tests/testapp/tests.py
+++ b/tests/testapp/tests.py
@@ -241,6 +241,12 @@ class RedisCacheTests(TestCase):
             self.cache.set(key, value)
             self.assertEqual(self.cache.get(key), value)
 
+    def test_binary_key(self):
+        key = '\xb6\r\x12\x1bC\x8a8\x0c4=^\xc3\xc2\x03ud\xb8/\xfe\xf3'
+        value = 'value'
+        self.cache.set(key, value)
+        self.assertEqual(self.cache.get(key), value)
+
     def test_binary_string(self):
         # Binary strings should be cachable
         from zlib import compress, decompress


### PR DESCRIPTION
I am using a redis-shard as a replacement for the redis client. 
The CacheKey failed this replacement since there are assertions that the key derives from basestring.
since this check makes sense to me, I thought it would be better (and require less code), to make CacheKey derive from str, so no proxy code is needed and it works with other clients.

I added an explicit test for binary keys just to make sure that is not harmed.
