### PR TITLE
Adds custom expire and persist methods

### DIFF
--- a/redis_cache/backends/base.py
+++ b/redis_cache/backends/base.py
@@ -418,3 +418,26 @@ class BaseRedisCache(BaseCache):
         Reinsert cache entries using the current pickle protocol version.
         """
         raise NotImplementedError
+
+    def _persist(self, client, key, version=None):
+        if client.exists(key):
+            client.persist(key)
+
+    def persist(self, key):
+        """
+        Remove the timeout on a key.  Equivalent to setting a timeout
+        of None in a set command.
+        """
+        raise NotImplementedError
+
+    def _expire(self, client, key, timeout, version=None):
+        if client.exists(key):
+            client.expire(key, timeout)
+
+    def expire(self, key, timeout):
+        """
+        Set the expire time on a key
+
+        Will raise an exception if the key does not exist
+        """
+        raise NotImplementedError

--- a/redis_cache/backends/multiple.py
+++ b/redis_cache/backends/multiple.py
@@ -222,3 +222,13 @@ class ShardedRedisCache(BaseRedisCache):
         for client in self.clients.itervalues():
             self._reinsert_keys(client)
         print
+
+    def persist(self, key, version=None):
+        client = self.get_client(key, for_write=True)
+        key = self.make_key(key, version=version)
+        self._persist(client, key, version)
+
+    def expire(self, key, timeout, version=None):
+        client = self.get_client(key, for_write=True)
+        key = self.make_key(key, version=version)
+        self._expire(client, key, timeout, version)

--- a/redis_cache/backends/single.py
+++ b/redis_cache/backends/single.py
@@ -151,3 +151,11 @@ class RedisCache(BaseRedisCache):
         Reinsert cache entries using the current pickle protocol version.
         """
         self._reinsert_keys(self.client)
+
+    def persist(self, key, version=None):
+        key = self.make_key(key, version=version)
+        self._persist(self.client, key, version)
+
+    def expire(self, key, timeout, version=None):
+        key = self.make_key(key, version=version)
+        self._expire(self.client, key, timeout, version)

--- a/tests/testapp/tests/base_tests.py
+++ b/tests/testapp/tests/base_tests.py
@@ -470,3 +470,27 @@ class BaseRedisTestCase(object):
         """
         ttl = self.cache.ttl('does_not_exist')
         self.assertEqual(ttl, 0)
+
+    def test_persist_expire_to_persist(self):
+        self.cache.set('a', 'a', timeout=10)
+        self.cache.persist('a')
+        ttl = self.cache.ttl('a')
+        self.assertEqual(ttl, None)
+
+    def test_expire_no_expiry_to_expire(self):
+        self.cache.set('a', 'a', timeout=None)
+        self.cache.expire('a', 10)
+        ttl = self.cache.ttl('a')
+        self.assertAlmostEqual(ttl, 10)
+
+    def test_expire_less(self):
+        self.cache.set('a', 'a', timeout=20)
+        self.cache.expire('a', 10)
+        ttl = self.cache.ttl('a')
+        self.assertAlmostEqual(ttl, 10)
+
+    def test_expire_more(self):
+        self.cache.set('a', 'a', timeout=10)
+        self.cache.expire('a', 20)
+        ttl = self.cache.ttl('a')
+        self.assertAlmostEqual(ttl, 20)


### PR DESCRIPTION
Use Redis' expire and persist methods

Better than getting and resetting keys in cache to change timeout