### PR TITLE
Fix python3.4 issue - dict_values object does not support indexing

### DIFF
--- a/redis_cache/backends/single.py
+++ b/redis_cache/backends/single.py
@@ -20,7 +20,7 @@ class RedisCache(BaseRedisCache):
             client = self.create_client(server)
             self.clients[client.connection_pool.connection_identifier] = client
 
-        self.client_list = self.clients.values()
+        self.client_list = list(self.clients.values())
         self.master_client = self.get_master_client()
 
     def get_client(self, key, write=False):


### PR DESCRIPTION
Function random.choice dont support dict_values indexing.

Sample:
variable = {'a': 1, 'b': 2}
values = variable.values()
print(values[0])  # error