### PR TITLE
RedisDummyCache

### DIFF
--- a/redis_cache/__init__.py
+++ b/redis_cache/__init__.py
@@ -1,2 +1,3 @@
 from redis_cache.backends.single import RedisCache
 from redis_cache.backends.multiple import ShardedRedisCache
+from redis_cache.backends.dummy import RedisDummyCache

--- a/redis_cache/backends/dummy.py
+++ b/redis_cache/backends/dummy.py
@@ -1,0 +1,24 @@
+from django.core.cache.backends.dummy import DummyCache
+
+
+class RedisDummyCache(DummyCache):
+    def ttl(self, key):
+        return 0
+
+    def delete_pattern(self, pattern, version=None):
+        raise NotImplementedError
+
+    def get_or_set(self, key, func, timeout=None):
+        if not callable(func):
+            raise Exception("Must pass in a callable")
+
+        return func()
+
+    def reinsert_keys(self):
+        raise NotImplementedError
+
+    def persist(self, key):
+        return True
+
+    def expire(self, key, timeout):
+        return True

--- a/redis_cache/backends/dummy.py
+++ b/redis_cache/backends/dummy.py
@@ -6,7 +6,7 @@ class RedisDummyCache(DummyCache):
         return 0
 
     def delete_pattern(self, pattern, version=None):
-        raise NotImplementedError
+        return None
 
     def get_or_set(self, key, func, timeout=None):
         if not callable(func):
@@ -15,7 +15,7 @@ class RedisDummyCache(DummyCache):
         return func()
 
     def reinsert_keys(self):
-        raise NotImplementedError
+        return None
 
     def persist(self, key):
         return True


### PR DESCRIPTION
Extended Django's dummy cache to allow for redis-cache only method calls in dummy mode.