### PR TITLE
Use line blocks to preserve AUTHORS formatting.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,21 +1,21 @@
-Sean Bleier <http://github.com/sebleier>
-Matt Dennewitz <http://github.com/blackbrrr>
-Jannis Leidel <http://github.com/jezdez>
-S. Angel / Twidi <http://github.com/twidi>
-Noah Kantrowitz / coderanger <http://github.com/coderanger>
-Martin Mahner / bartTC <http://github.com/bartTC>
-Timothée Peignier / cyberdelia <https://github.com/cyberdelia>
-Lior Sion / liorsion <https://github.com/liorsion>
-Ales Zoulek / aleszoulek <https://github.com/aleszoulek>
-James Aylett / jaylett <https://github.com/jaylett>
-Todd Boland / boland <https://github.com/boland>
-Issac Kelly / issackelly <https://github.com/issackelly>
-Saverio / mucca <https://github.com/mucca>
-Matt Robenolt / mattrobenolt <https://github.com/mattrobenolt>
-Carl Meyer / carljm <https://github.com/carljm>
-wtracyliu / wtracyliu <https://github.com/wtracyliu>
-Florent Messa / thoas <https://github.com/thoas>
-Markus Kaiserswerth / mkai <https://github.com/mkai>
-Michael Lindemuth / mlindemu <https://github.com/mlindemu>
-John Furr / gnulnx <https://github.com/gnulnx>
-Christian Pedersen / chripede <https://github.com/chripede>
+| Sean Bleier <http://github.com/sebleier>
+| Matt Dennewitz <http://github.com/blackbrrr>
+| Jannis Leidel <http://github.com/jezdez>
+| S. Angel / Twidi <http://github.com/twidi>
+| Noah Kantrowitz / coderanger <http://github.com/coderanger>
+| Martin Mahner / bartTC <http://github.com/bartTC>
+| Timothée Peignier / cyberdelia <https://github.com/cyberdelia>
+| Lior Sion / liorsion <https://github.com/liorsion>
+| Ales Zoulek / aleszoulek <https://github.com/aleszoulek>
+| James Aylett / jaylett <https://github.com/jaylett>
+| Todd Boland / boland <https://github.com/boland>
+| Issac Kelly / issackelly <https://github.com/issackelly>
+| Saverio / mucca <https://github.com/mucca>
+| Matt Robenolt / mattrobenolt <https://github.com/mattrobenolt>
+| Carl Meyer / carljm <https://github.com/carljm>
+| wtracyliu / wtracyliu <https://github.com/wtracyliu>
+| Florent Messa / thoas <https://github.com/thoas>
+| Markus Kaiserswerth / mkai <https://github.com/mkai>
+| Michael Lindemuth / mlindemu <https://github.com/mlindemu>
+| John Furr / gnulnx <https://github.com/gnulnx>
+| Christian Pedersen / chripede <https://github.com/chripede>


### PR DESCRIPTION
Use line blocks to make sure that each entry in AUTHORS.rst appears on
its own line, as opposed to squished up in one paragraph.