### PR TITLE
get_many and set_many should work the same way as in other cache backends

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@
 | Michael Lindemuth / mlindemu <https://github.com/mlindemu>
 | John Furr / gnulnx <https://github.com/gnulnx>
 | Christian Pedersen / chripede <https://github.com/chripede>
+| Joona Pääkkönen / paksu <https://github.com/paksu>

--- a/redis_cache/backends/base.py
+++ b/redis_cache/backends/base.py
@@ -302,12 +302,14 @@ class BaseRedisCache(BaseCache):
         recovered_data = {}
         map_keys = dict(zip(versioned_keys, original_keys))
 
-        results = client.mget(versioned_keys)
+        # Only try to mget if we actually received any keys to get
+        if map_keys:
+            results = client.mget(versioned_keys)
 
-        for key, value in zip(versioned_keys, results):
-            if value is None:
-                continue
-            recovered_data[map_keys[key]] = self.get_value(value)
+            for key, value in zip(versioned_keys, results):
+                if value is None:
+                    continue
+                recovered_data[map_keys[key]] = self.get_value(value)
 
         return recovered_data
 

--- a/redis_cache/backends/base.py
+++ b/redis_cache/backends/base.py
@@ -318,6 +318,9 @@ class BaseRedisCache(BaseCache):
         raise NotImplementedError
 
     def _set_many(self, client, data):
+        # Only call mset if there actually is some data to save
+        if not data:
+            return True
         return client.mset(data)
 
     def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):

--- a/tests/testapp/tests/base_tests.py
+++ b/tests/testapp/tests/base_tests.py
@@ -345,6 +345,11 @@ class BaseRedisTestCase(SetupMixin):
         self.assertEqual(self.cache.get("key1"), "spam")
         self.assertEqual(self.cache.get("key2"), "eggs")
 
+    def test_set_many_works_with_empty_dict(self):
+        # This test passes if no exception is raised
+        self.cache.set_many({})
+        self.cache.set_many({}, version=2)
+
     def test_set_many_expiration(self):
         # set_many takes a second ``timeout`` parameter
         self.cache.set_many({"key1": "spam", "key2": "eggs"}, 1)

--- a/tests/testapp/tests/base_tests.py
+++ b/tests/testapp/tests/base_tests.py
@@ -176,6 +176,9 @@ class BaseRedisTestCase(SetupMixin):
         self.assertEqual(self.cache.get_many(['a', 'c', 'd']), {'a': 'a', 'c': 'c', 'd': 'd'})
         self.assertEqual(self.cache.get_many(['a', 'b', 'e']), {'a': 'a', 'b': 'b'})
 
+    def test_get_many_works_with_empty_keys_array(self):
+        self.assertEqual(self.cache.get_many([]), {})
+
     def test_get_many_with_manual_integer_insertion(self):
         keys = ['a', 'b', 'c', 'd']
         for i, key in enumerate(keys):


### PR DESCRIPTION
Fix  `set_many` and `get_many` to handle empty params and added regression tests.

This is the same behaviour that other Django cache backends have.