### PR TITLE
Use default timeout in set_many.

### DIFF
--- a/redis_cache/backends/multiple.py
+++ b/redis_cache/backends/multiple.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 
 from redis_cache.backends.base import BaseRedisCache
+from redis_cache.compat import DEFAULT_TIMEOUT
 from redis_cache.sharder import HashRing
 
 
@@ -71,7 +72,7 @@ class ShardedRedisCache(BaseRedisCache):
             )
         return data
 
-    def set_many(self, data, timeout=None, version=None):
+    def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
         """
         Set a bunch of values in the cache at once from a dict of key/value
         pairs. This is much more efficient than calling set() multiple times.
@@ -79,6 +80,8 @@ class ShardedRedisCache(BaseRedisCache):
         If timeout is given, that timeout will be used for the key; otherwise
         the default cache timeout will be used.
         """
+        timeout = self.get_timeout(timeout)
+
         clients = self.shard(data.keys(), write=True, version=version)
 
         if timeout is None:

--- a/redis_cache/backends/single.py
+++ b/redis_cache/backends/single.py
@@ -1,3 +1,5 @@
+from redis_cache.compat import DEFAULT_TIMEOUT
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -52,7 +54,7 @@ class RedisCache(BaseRedisCache):
         versioned_keys = self.make_keys(keys, version=version)
         return self._get_many(self.master_client, keys, versioned_keys=versioned_keys)
 
-    def set_many(self, data, timeout=None, version=None):
+    def set_many(self, data, timeout=DEFAULT_TIMEOUT, version=None):
         """
         Set a bunch of values in the cache at once from a dict of key/value
         pairs. This is much more efficient than calling set() multiple times.
@@ -60,6 +62,8 @@ class RedisCache(BaseRedisCache):
         If timeout is given, that timeout will be used for the key; otherwise
         the default cache timeout will be used.
         """
+        timeout = self.get_timeout(timeout)
+
         versioned_keys = self.make_keys(data.keys(), version=version)
         if timeout is None:
             new_data = {}


### PR DESCRIPTION
We discovered this when we tried to use a Redis instance configured with "volatile-lru". Keys that were cached with "set_many" (from e.g. cache machine) did not have an expiry set and where never flushed by Redis. This fixes that.