### PR TITLE
Added DummySerializer to use when values to get/set are already seria…

### DIFF
--- a/redis_cache/serializers.py
+++ b/redis_cache/serializers.py
@@ -70,3 +70,14 @@ class YAMLSerializer(BaseSerializer):
 
     def deserialize(self, value):
         return yaml.load(value)
+
+class DummySerializer(BaseSerializer):
+
+    def __init__(self, **kwargs):
+        super(DummySerializer, self).__init__(**kwargs)
+
+    def serialize(self, value):
+        return value
+
+    def deserialize(self, value):
+        return value


### PR DESCRIPTION
…lized

The need arose when I wanted to cache serialized output of django-tastypie list endpoints. The output was json already, so it makes no sense to re-serialize it with pickle parser or json parser.