### PR TITLE
fix ignored version in first get_or_set fetch

### DIFF
--- a/redis_cache/backends/base.py
+++ b/redis_cache/backends/base.py
@@ -405,7 +405,7 @@ class BaseRedisCache(BaseCache):
         if not callable(func):
             raise Exception("Must pass in a callable")
 
-        value = self.get(key._original_key)
+        value = self.get(key)
 
         if value is None:
 

--- a/tests/testapp/tests/base_tests.py
+++ b/tests/testapp/tests/base_tests.py
@@ -491,22 +491,23 @@ class BaseRedisTestCase(SetupMixin):
 
         expensive_function.num_calls = 0
         self.assertEqual(expensive_function.num_calls, 0)
-        value = self.cache.get_or_set('a', expensive_function, 1)
+        value = self.cache.get_or_set('a', expensive_function, 1, version=2)
         self.assertEqual(expensive_function.num_calls, 1)
         self.assertEqual(value, 42)
 
-        value = self.cache.get_or_set('a', expensive_function, 1)
+        value = self.cache.get_or_set('a', expensive_function, 1, version=2)
         self.assertEqual(expensive_function.num_calls, 1)
         self.assertEqual(value, 42)
 
-        value = self.cache.get_or_set('a', expensive_function, 1)
+        value = self.cache.get_or_set('a', expensive_function, 1, version=2)
         self.assertEqual(expensive_function.num_calls, 1)
         self.assertEqual(value, 42)
 
         time.sleep(2)
-        value = self.cache.get_or_set('a', expensive_function, 1)
+        value = self.cache.get_or_set('a', expensive_function, 1, version=2)
         self.assertEqual(expensive_function.num_calls, 2)
         self.assertEqual(value, 42)
+
 
     def assertMaxConnection(self, cache, max_num):
         for client in cache.clients.values():


### PR DESCRIPTION
Fixes https://github.com/sebleier/django-redis-cache/issues/122

get_or_set had been ignoring the key's version in it's attempt to fetch the key from cache initially. When using a versioned key, get_or_set therefore always misses the cache, runs the expensive function, and then updates the right key in the cache.

I'm having some getting the tests to pass, but here is some example code to show the issue.

```
cache.set('x', 'yay', version=2)
cache.set('x', 'boo')

cache.get_or_set('x', lambda: 'x', version=2)
> 'boo'

cache.get('x')
> 'yay'
```