### PR TITLE
Add license to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     author="Sean Bleier",
     author_email="sebleier@gmail.com",
     version="1.7.1",
+    license="BSD",
     packages=["redis_cache", "redis_cache.backends"],
     description="Redis Cache Backend for Django",
     install_requires=['redis>=2.10.3'],

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",


### PR DESCRIPTION
This makes it easy to see the license at-a-glance from services such as pyup.io