### PR TITLE
MASTER_WRITE_ONLY option

### DIFF
--- a/redis_cache/backends/base.py
+++ b/redis_cache/backends/base.py
@@ -162,7 +162,7 @@ class BaseRedisCache(BaseCache):
         """
         cache = self.options.get('MASTER_CACHE', None)
         if cache is None:
-            return next(iter(self.client_list))
+            return next(iter(self.clients.values()))
 
         kwargs = parse_connection_kwargs(cache, db=self.db)
         return self.clients[(

--- a/tests/testapp/tests/master_slave_tests.py
+++ b/tests/testapp/tests/master_slave_tests.py
@@ -28,6 +28,18 @@ LOCATIONS = [
             'MASTER_CACHE': MASTER_LOCATION,
         },
     },
+    'master_write_only': {
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': LOCATIONS,
+        'OPTIONS': {
+            'DB': 1,
+            'PASSWORD': 'yadayada',
+            'PARSER_CLASS': 'redis.connection.HiredisParser',
+            'PICKLE_VERSION': -1,
+            'MASTER_CACHE': MASTER_LOCATION,
+            'MASTER_WRITE_ONLY': True,
+        },
+    },
 })
 class MasterSlaveTestCase(SetupMixin, TestCase):
 
@@ -93,3 +105,8 @@ class MasterSlaveTestCase(SetupMixin, TestCase):
         time.sleep(.2)
         for client in self.cache.clients.values():
             self.assertEqual(len(client.keys('*')), 0)
+
+    def test_client_list(self):
+        cache = self.get_cache('master_write_only')
+        master = cache.get_master_client()
+        self.assertNotIn(master, cache.client_list)


### PR DESCRIPTION
MASTER_WRITE_ONLY option allows to send master only write queries. All read queries will be send to slaves.