### PR TITLE
fix set method

### DIFF
--- a/redis_cache/backends/base.py
+++ b/redis_cache/backends/base.py
@@ -280,9 +280,7 @@ class BaseRedisCache(BaseCache):
         """
         timeout = self.get_timeout(timeout)
 
-        result = self._set(client, key, self.prep_value(value), timeout, _add_only=False)
-
-        return result
+        self._set(client, key, self.prep_value(value), timeout, _add_only=False)
 
     @get_client(write=True)
     def delete(self, client, key):


### PR DESCRIPTION
cache.set()  method should return None, cause in other case it break down django.middleware.cache.UpdateCacheMiddleware (django 1.9)
at this line 
```
response.add_post_render_callback( lambda r: self.cache.set(cache_key, r, timeout) )
```
cause if lambda-function return is not None value, then response.render()  return value from lambda-function (True in the case), but it should return response object.