### PR TITLE
Read operations only from slaves

### DIFF
--- a/docs/advanced_configuration.rst
+++ b/docs/advanced_configuration.rst
@@ -135,7 +135,52 @@ read/write server and secondary servers as read-only.
         }
     }
 
+Additionally if you set ``MASTER_CACHE_ONLY_FOR_WRITE`` to True the primary
+server will be write-only.
 
+**For example:**
+
+Two data centers - DC1 and DC2. Redis master is in DC1, slave in DC2. With
+MASTER_CACHE_ONLY_FOR_WRITE option it's possible to configure application
+instances to write to the master and read from the closer data center.
+
+DC1 configuration:
+
+.. code:: python
+
+    CACHES = {
+        'default': {
+            'LOCATION': [
+                '10.10.0.1:6379',  # Master, DC1
+            ],
+            'OPTIONS': {
+                'PASSWORD': 'yadayada',
+                'MASTER_CACHE': '10.10.0.1:6379',
+                ...
+            },
+            ...
+        }
+    }
+
+DC2 configuration:
+
+.. code:: python
+
+    CACHES = {
+        'default': {
+            'LOCATION': [
+                '10.10.0.1:6379',  # Master, DC1
+                '10.20.0.1:6379',  # Slave, DC2
+            ],
+            'OPTIONS': {
+                'PASSWORD': 'yadayada',
+                'MASTER_CACHE': '10.10.0.1:6379',
+                'MASTER_CACHE_ONLY_FOR_WRITE': True,
+                ...
+            },
+            ...
+        }
+    }
 
 
 Pluggable Parser Classes

--- a/install_redis.sh
+++ b/install_redis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-: ${REDIS_VERSION:="2.6"}
+: ${REDIS_VERSION:="2.8"}
 
 test -d redis || git clone https://github.com/antirez/redis
 git -C redis checkout $REDIS_VERSION


### PR DESCRIPTION
With ``MASTER_CACHE_ONLY_FOR_WRITE`` option, it's possible to use only slaves for read operations (as described in documentation). It could be useful when you have your Redis servers in different data centers and you want to read always from closer DC.