### PR TITLE
Revive "Download" badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Redis Django Cache Backend
 ==========================
 
-.. image:: https://img.shields.io/pypi/dm/django-redis-cache.svg
-    :target: https://pypi.python.org/pypi//django-redis-cache/
+.. image:: https://pepy.tech/badge/django-redis-cache
+    :target: https://pepy.tech/project/django-redis-cache
     :alt: Downloads
 
 .. image:: https://img.shields.io/pypi/v/django-redis-cache.svg


### PR DESCRIPTION
PyPI does not provide download counts of packages anymore and shields.io does not too.

This PR replace shields.io's badge with the alternative one provided by the PePy project.

See also: [python - Why PyPi doesn't show download stats anymore? - Stack Overflow](https://stackoverflow.com/questions/38102317/why-pypi-doesnt-show-download-stats-anymore)