### PR TITLE
Support for projects using Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - DJANGO_VERSION='>=2.0,<2.1'
   - DJANGO_VERSION='>=2.1,<2.2'
   - DJANGO_VERSION='==2.2b1'
+  - DJANGO_VERSION='==3.0a1'
 matrix:
   exclude:
     - python: 2.7
@@ -18,6 +19,8 @@ matrix:
       env: DJANGO_VERSION='>=2.1,<2.2'
     - python: 2.7
       env: DJANGO_VERSION='==2.2b1'
+    - python: 2.7
+      env: DJANGO_VERISON='==3.0a1'
     - python: 3.5
       env: DJANGO_VERSION='<2.0'
     - python: 3.6

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,3 +23,4 @@
 | Joona Pääkkönen / paksu <https://github.com/paksu>
 | Tim Graham / timgraham <https://github.com/timgraham>
 | Justin Arulnathan / dinie <justin@gizmag.com>
+| Chris Cameron / unchris <https://github.com/unchris>

--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,7 @@ Requirements
 `redis`_ >= 2.4
 `hiredis`_
 `python`_ >= 2.7
+`six`
 
 1. Run ``pip install django-redis-cache``.
 
@@ -331,7 +332,7 @@ Example::
 Running Tests
 =============
 
-``./install_redis.sh``
+``./install_redis.sh`` (run `sudo xcodebuild -license` first if you're on MacOS so you can use the xcode build tools )
 
 ``make test``
 

--- a/redis_cache/utils.py
+++ b/redis_cache/utils.py
@@ -2,9 +2,9 @@ import importlib
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
+import six
 from django.utils.encoding import force_text, python_2_unicode_compatible
-from django.utils.six.moves.urllib.parse import parse_qs, urlparse
+from six.moves.urllib.parse import parse_qs, urlparse
 
 from redis._compat import unicode
 from redis.connection import SSLConnection

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 redis<4.0
+six

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     license="BSD",
     packages=["redis_cache", "redis_cache.backends"],
     description="Redis Cache Backend for Django",
-    install_requires=['redis<4.0'],
+    install_requires=['redis<4.0','six'],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
Hello maintainers,

I have created a PR which replaces `django.utils.six` with `six` so that `django-redis-cache` can be imported in projects using Django 3.0. 

I ran tests locally and everything passed fine. I've added some targets for Travis CI and hopefully they pass as well.

Other projects often request that PR submitters add themselves to the authors page. Please advise if that is incorrect for your project and I'll remove that from the diff

Thanks!