### PR TITLE
docs: Fix simple typo, volitile -> volatile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -164,7 +164,7 @@ This will lead to some cache misses, so be aware.
 * Keys can now be kept alive indefinitely by setting the timeout to None,
     e.g. `cache.set('key', 'value', timeout=None)`
 * Adds `ttl` method to the cache.  `cache.ttl(key)` will return the number of
-    seconds before it expires or None if the key is not volitile.
+    seconds before it expires or None if the key is not volatile.
 
 0.11.0
 ------

--- a/redis_cache/backends/base.py
+++ b/redis_cache/backends/base.py
@@ -368,7 +368,7 @@ class BaseRedisCache(BaseCache):
 
     @get_client()
     def ttl(self, client, key):
-        """Returns the 'time-to-live' of a key.  If the key is not volitile,
+        """Returns the 'time-to-live' of a key.  If the key is not volatile,
         i.e. it has not set expiration, then the value returned is None.
         Otherwise, the value is the number of seconds remaining.  If the key
         does not exist, 0 is returned.


### PR DESCRIPTION
There is a small typo in README.rst, redis_cache/backends/base.py.

Should read `volatile` rather than `volitile`.

