### PR TITLE
Set django requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     license="BSD",
     packages=["redis_cache", "redis_cache.backends"],
     description="Redis Cache Backend for Django",
-    install_requires=['redis<4.0'],
+    install_requires=['redis<4.0', 'Django>=3.0'],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
This adds django 3.0 to the requirements list. Without it listed like this, dependency management tools will think that this version can be installed on older versions of django. In our case, dependabot recommended that we upgrade to version 3.0 of this library, but we do not have a compatible version of django. 

It'd be great to get this small fix in place.