### PR TITLE
Compressed variants of the serializers.

### DIFF
--- a/redis_cache/serializers.py
+++ b/redis_cache/serializers.py
@@ -24,9 +24,6 @@ from django.utils.encoding import force_bytes, force_str
 
 
 class BaseSerializer(object):
-    def __init__(self, **kwargs):
-        super(BaseSerializer, self).__init__(**kwargs)
-
     def serialize(self, value):
         raise NotImplementedError
 
@@ -58,9 +55,6 @@ class CompressedPickleSerializer(CompressedMixin, PickleSerializer):
 
 
 class JSONSerializer(BaseSerializer):
-    def __init__(self, **kwargs):
-        super(JSONSerializer, self).__init__(**kwargs)
-
     def serialize(self, value):
         return force_bytes(json.dumps(value))
 
@@ -97,9 +91,6 @@ class CompressedYAMLSerializer(CompressedMixin, YAMLSerializer):
 
 
 class DummySerializer(BaseSerializer):
-    def __init__(self, **kwargs):
-        super(DummySerializer, self).__init__(**kwargs)
-
     def serialize(self, value):
         return value
 

--- a/redis_cache/serializers.py
+++ b/redis_cache/serializers.py
@@ -24,7 +24,6 @@ from django.utils.encoding import force_bytes, force_str
 
 
 class BaseSerializer(object):
-
     def __init__(self, **kwargs):
         super(BaseSerializer, self).__init__(**kwargs)
 
@@ -44,7 +43,6 @@ class CompressedMixin:
 
 
 class PickleSerializer(object):
-
     def __init__(self, pickle_version=-1):
         self.pickle_version = pickle_version
 
@@ -58,8 +56,8 @@ class PickleSerializer(object):
 class CompressedPickleSerializer(CompressedMixin, PickleSerializer):
     pass
 
-class JSONSerializer(BaseSerializer):
 
+class JSONSerializer(BaseSerializer):
     def __init__(self, **kwargs):
         super(JSONSerializer, self).__init__(**kwargs)
 
@@ -73,13 +71,13 @@ class JSONSerializer(BaseSerializer):
 class CompressedJSONSerializer(CompressedMixin, JSONSerializer):
     pass
 
-class MSGPackSerializer(BaseSerializer):
 
+class MSGPackSerializer(BaseSerializer):
     def serialize(self, value):
         return msgpack.dumps(value)
 
     def deserialize(self, value):
-        return msgpack.loads(value, encoding='utf-8')
+        return msgpack.loads(value, encoding="utf-8")
 
 
 class CompressedMSGPackSerializer(CompressedMixin, MSGPackSerializer):
@@ -87,9 +85,8 @@ class CompressedMSGPackSerializer(CompressedMixin, MSGPackSerializer):
 
 
 class YAMLSerializer(BaseSerializer):
-
     def serialize(self, value):
-        return yaml.dump(value, encoding='utf-8', Dumper=yaml.Dumper)
+        return yaml.dump(value, encoding="utf-8", Dumper=yaml.Dumper)
 
     def deserialize(self, value):
         return yaml.load(value, Loader=yaml.FullLoader)
@@ -100,7 +97,6 @@ class CompressedYAMLSerializer(CompressedMixin, YAMLSerializer):
 
 
 class DummySerializer(BaseSerializer):
-
     def __init__(self, **kwargs):
         super(DummySerializer, self).__init__(**kwargs)
 


### PR DESCRIPTION
Often JSON/YAML/pickle can produce large blobs with a lot of duplicated data.

By using a fast compressor, this can result in both faster writing and reading because the "bandwidth" between the Django layer and the database is smaller, and therefore more efficient. Yes, compressing takes some time as well, but for certain types of data (like pickled dataframes for example), this might pay off, and overall speed up processing.